### PR TITLE
Fix contact details not being added to payload

### DIFF
--- a/veracode_api_py/dynamic.py
+++ b/veracode_api_py/dynamic.py
@@ -306,6 +306,7 @@ class DynUtils():
       payload.update( scan_config_request )
       if scan_contact_info is None:
          scan_contact_info = self.setup_scan_contact_info("", "", "")
+         payload.update(scan_contact_info)
       if linked_app_guid != None:
          payload.update({'linked_platform_app_uuid': linked_app_guid})
       return payload


### PR DESCRIPTION
Scan updates were failing as the required contact info was not being added to the payload